### PR TITLE
The `encode_mapper` seems to fail in the infer_zeroshot_text method for GradedMonoPrompt

### DIFF
--- a/autoqrels/oneshot/duoprompt.py
+++ b/autoqrels/oneshot/duoprompt.py
@@ -122,7 +122,7 @@ class DuoPrompt(OneShotLabeler):
     def predict(self, df):
         ret = {}
         df = df.copy()
-        for i in tqdm(_batches(df)):
+        for i in tqdm(self._batches(df)):
             preds = self.infer_oneshot_text(i['query'], i['relevant'], i['texts'])
             assert len(preds) == len(i['dids'])
             for id, pred in zip(i['dids'], preds):

--- a/autoqrels/oneshot/duoprompt.py
+++ b/autoqrels/oneshot/duoprompt.py
@@ -95,7 +95,7 @@ class DuoPrompt(OneShotLabeler):
     def model(self):
         return AutoModelForSeq2SeqLM.from_pretrained(self.backbone).eval().to(self.device)
 
-    def _group_per_query_and_relevant(df):
+    def _group_per_query_and_relevant(self, df):
         inps = {}
 
         for _, i in df.iterrows():

--- a/autoqrels/oneshot/duoprompt.py
+++ b/autoqrels/oneshot/duoprompt.py
@@ -22,7 +22,7 @@ class DuoPrompt(OneShotLabeler):
         "Is passage B as relevant as passage A? </s>"
     )
 
-    def __init__(self, dataset, backbone='google/flan-t5-xl', device=None, batch_size=8, verbose=False, query_field=None, doc_field=None, max_src_len=330, cache_path=None):
+    def __init__(self, dataset, backbone='google/flan-t5-xl', device=None, batch_size=8, verbose=False, query_field=None, doc_field=None, max_src_len=330, cache_path=None, prompt=PROMPT):
         super().__init__(cache_path=cache_path)
         self.backbone = backbone
         self.tokeniser = AutoTokenizer.from_pretrained(backbone)
@@ -37,7 +37,8 @@ class DuoPrompt(OneShotLabeler):
         self.query_field = query_field
         self.doc_field = doc_field
         fields = ['query_text', 'rel_doc_text', 'unk_doc_text']
-        m_jinja = smashed.mappers.JinjaMapper(jinja=self.PROMPT)
+        self.prompt = prompt
+        m_jinja = smashed.mappers.JinjaMapper(jinja=self.prompt)
         m_txt2word = smashed.mappers.TextToWordsMapper(
             fields=fields,
         )

--- a/autoqrels/oneshot/duoprompt.py
+++ b/autoqrels/oneshot/duoprompt.py
@@ -95,42 +95,42 @@ class DuoPrompt(OneShotLabeler):
     def model(self):
         return AutoModelForSeq2SeqLM.from_pretrained(self.backbone).eval().to(self.device)
 
-def _group_per_query_and_relevant(df):
-    inps = {}
+    def _group_per_query_and_relevant(df):
+        inps = {}
 
-    for _, i in df.iterrows():
-        if i['query'] not in inps:
-            inps[i['query']] = {}
-        if i['relevant'] not in inps[i['query']]:
-            inps[i['query']][i['relevant']] = {}
-        
-        inps[i['query']][i['relevant']][i['id']] = i['unknown']
-    return inps
+        for _, i in df.iterrows():
+            if i['query'] not in inps:
+                inps[i['query']] = {}
+            if i['relevant'] not in inps[i['query']]:
+                inps[i['query']][i['relevant']] = {}
 
-def _batches(df):
-    grouped = _group_per_query_and_relevant(df)
-    ret = []
-    for query in grouped.keys():
-        for relevant in grouped[query]:
-            tmp = {'query': query, 'relevant': relevant, 'dids': [], 'texts': []}
-            for did, text in grouped[query][relevant].items():
-                tmp['dids'].append(did)
-                tmp['texts'].append(text)
-            ret.append(tmp)
-    return ret
+            inps[i['query']][i['relevant']][i['id']] = i['unknown']
+        return inps
 
-def predict(self, df):
-    ret = {}
-    df = df.copy()
-    for i in tqdm(_batches(df)):
-        preds = self.infer_oneshot_text(i['query'], i['relevant'], i['texts'])
-        assert len(preds) == len(i['dids'])
-        for id, pred in zip(i['dids'], preds):
-            assert id not in ret
-            ret[id] = pred
-    df['probability_relevant'] = df['id'].apply(lambda i: ret[i])
+    def _batches(self, df):
+        grouped = self._group_per_query_and_relevant(df)
+        ret = []
+        for query in grouped.keys():
+            for relevant in grouped[query]:
+                tmp = {'query': query, 'relevant': relevant, 'dids': [], 'texts': []}
+                for did, text in grouped[query][relevant].items():
+                    tmp['dids'].append(did)
+                    tmp['texts'].append(text)
+                ret.append(tmp)
+        return ret
 
-    return df
+    def predict(self, df):
+        ret = {}
+        df = df.copy()
+        for i in tqdm(_batches(df)):
+            preds = self.infer_oneshot_text(i['query'], i['relevant'], i['texts'])
+            assert len(preds) == len(i['dids'])
+            for id, pred in zip(i['dids'], preds):
+                assert id not in ret
+                ret[id] = pred
+        df['probability_relevant'] = df['id'].apply(lambda i: ret[i])
+
+        return df
 
     def _infer_oneshot(self, query_id: str, rel_doc_id: str, unk_doc_ids: List[str]) -> List[float]:
         return self.infer_oneshot_text(

--- a/autoqrels/zeroshot/gradedmonoprompt.py
+++ b/autoqrels/zeroshot/gradedmonoprompt.py
@@ -45,7 +45,7 @@ Question: {{ query_text }}
 Passage: {{ unk_doc_text }}
 Answer:"""
 
-    def __init__(self, dataset, backbone='google/flan-t5-xl', device=None, batch_size=16, verbose=False, query_field=None, doc_field=None, max_src_len=330, cache_path=None):
+    def __init__(self, dataset, backbone='google/flan-t5-xl', device=None, batch_size=16, verbose=False, query_field=None, doc_field=None, max_src_len=330, cache_path=None, prompt=PROMPT):
         super().__init__(cache_path=cache_path)
         self.backbone = backbone
         self.tokeniser = AutoTokenizer.from_pretrained(backbone)
@@ -60,7 +60,7 @@ Answer:"""
         self.query_field = query_field
         self.doc_field = doc_field
         fields = ['query_text', 'rel_doc_text', 'unk_doc_text']
-        m_jinja = smashed.mappers.JinjaMapper(jinja=self.PROMPT)
+        m_jinja = smashed.mappers.JinjaMapper(jinja=prompt)
         m_txt2word = smashed.mappers.TextToWordsMapper(
             fields=(),
         )

--- a/autoqrels/zeroshot/gradedmonoprompt.py
+++ b/autoqrels/zeroshot/gradedmonoprompt.py
@@ -7,6 +7,7 @@ import torch
 from transformers import AutoModelForSeq2SeqLM, AutoTokenizer
 import smashed
 import autoqrels
+import pandas as pd
 from . import ZeroShotLabeler
 
 

--- a/autoqrels/zeroshot/gradedmonoprompt.py
+++ b/autoqrels/zeroshot/gradedmonoprompt.py
@@ -69,13 +69,6 @@ Answer:"""
         )
         self.encode_mapper = (
             m_txt2word
-            >> smashed.mappers.TruncateMultipleNestedFieldsMapper(
-                fields_to_truncate=fields,
-                max_length=prompt_length,
-            )
-            >> smashed.mappers.WordsToTextMapper(
-                fields=fields,
-            )
             >> m_jinja
             >> smashed.mappers.TokenizerMapper(
                 tokenizer=self.tokeniser,

--- a/autoqrels/zeroshot/gradedmonoprompt.py
+++ b/autoqrels/zeroshot/gradedmonoprompt.py
@@ -121,7 +121,7 @@ Answer:"""
             autoqrels.text.query_text(self.dataset, query_id, self.query_field),
             autoqrels.text.doc_text(self.dataset, unk_doc_ids, self.doc_field))
 
-    def infer_zeroshot_text(self, query_text: str, unk_doc_text: List[str]) -> List[float]:
+    def infer_zeroshot_text(self, query_text: str, unk_doc_texts: List[str]) -> List[float]:
         prompt_data = self.encode_mapper.map([
             {'query_text': query_text, 'unk_doc_text': unk_doc_text}
             for unk_doc_text in unk_doc_texts

--- a/autoqrels/zeroshot/gradedmonoprompt.py
+++ b/autoqrels/zeroshot/gradedmonoprompt.py
@@ -62,7 +62,7 @@ Answer:"""
         fields = ['query_text', 'rel_doc_text', 'unk_doc_text']
         m_jinja = smashed.mappers.JinjaMapper(jinja=self.PROMPT)
         m_txt2word = smashed.mappers.TextToWordsMapper(
-            fields=fields,
+            fields=(),
         )
         prompt_length = max_src_len - len(
             m_txt2word.splitter(m_jinja.template_text[0])


### PR DESCRIPTION
I had the use case of using the GradedMonoPrompt without ir_datasets by directly providing the query and document text to the `infer_zeroshot_text` methods.

The below changes made it work, and the outputs seem to look good for a small example dataset. Still, I think my changes would break the `_infer_zeroshot` as I removed the extraction of fields from the `encode_mapper` for the moment.

Maybe one would need two pipelines? Or Maybe the field mapping is not needed, as the `autoqrels.text.query_text` and `autoqrels.text.doc_text` methods are used in the `_infer_zeroshot` method?

This is currently still an draft pull request until we decided how to ensure that it also works for the `_infer_zeroshot` method.

Best regards,

Maik